### PR TITLE
Move trivia API call api folder

### DIFF
--- a/src/pages/api/trivia.ts
+++ b/src/pages/api/trivia.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+interface QuizModel {
+  category: string
+  id: string
+  correctAnswer: string
+  incorrectAnswers: string[]
+  question: {
+    text: string
+  }
+  tags: string[]
+  type: string
+  difficulty: string
+  regions: string[]
+  isNiche: boolean
+}
+
+const TRIVIA_API_URL = 'https://the-trivia-api.com/v2/questions'
+const defaultQuestionsLimit = 3
+const defaultDifficulty = 'easy, medium, hard'
+const defaultCategories: string[] = []
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<QuizModel[] | any>
+) {
+  try {
+    const { categories = defaultCategories, questionsLimit = defaultQuestionsLimit, difficulty = defaultDifficulty} = req?.query
+    let result = await fetch(`${TRIVIA_API_URL}?limit=${questionsLimit}&difficulty=${difficulty}&categories=${categories}`)
+    result = await result.json()
+    res.status(200).json(result)
+
+  } catch (error) {
+    console.log(`Error /api/trivia/ error =${error}`)
+    return res.status(500).json({ error })
+  }
+}

--- a/src/trivaAPI/triviaAPI.ts
+++ b/src/trivaAPI/triviaAPI.ts
@@ -1,9 +1,0 @@
-export const triviaAPI = async (apiURL: string) /* FIX ME: return type */ => {
-  if (!apiURL || !apiURL.length) return null
-  try {
-    const res = await fetch(apiURL)
-    return await res.json()
-  } catch (error) {
-    return error
-  }
-}


### PR DESCRIPTION
moves code to quiz api endpoint --> `https://the-trivia-api.com/docs/v2/questions` into the next.js `/pages/api/` pathway to opt into server side code later on.