### PR TITLE
chore: setup path aliases for import

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,13 +1,8 @@
-import '../styles/globals.css'
+import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 
 function MyApp({ Component, pageProps }: AppProps) {
-
-
-
-  return (
-    <Component {...pageProps} />
-  )
+  return <Component {...pageProps} />
 }
 
 export default MyApp

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link'
 import Image from 'next/image'
-import styles from '../styles/Home.module.css'
-import Layout from '../components/Layout'
+import styles from '@/styles/Home.module.css'
+import Layout from '@/components/Layout'
 import { NextPage } from 'next'
-import generate from '../assets/icons/solution-icon.png'
-import view from '../assets/icons/thought-cloud-icon.png'
+import generate from '@/assets/icons/solution-icon.png'
+import view from '@/assets/icons/thought-cloud-icon.png'
 
 const Home: NextPage = () => {
   return (
@@ -12,17 +12,20 @@ const Home: NextPage = () => {
       <Layout>
         <main className={styles.main}>
           <section>
-            <Link href={'/generate'} className='main-option'>
-              <Image src={generate} className='icon' alt='' />
-              Generate a quiz
+            <Link href={'/generate'} className="main-option">
+              <div>
+                <Image src={generate} className="icon" alt="" />
+                <p>Generate a quiz</p>
+              </div>
             </Link>
-            <Link href={'/view'} className='main-option'>
-              <Image src={view} className='icon' alt='' />
-              Stored quizzes
+            <Link href={'/view'} className="main-option">
+              <div>
+                <Image src={view} className="icon" alt="" />
+                Stored quizzes
+              </div>
             </Link>
           </section>
         </main>
-
       </Layout>
     </div>
   )

--- a/src/utils/__tests__/helpers.test.ts
+++ b/src/utils/__tests__/helpers.test.ts
@@ -1,12 +1,18 @@
 import { expect, test, describe } from 'vitest'
-import helpers, { triviaAPIDetails } from '../helpers'
+import helpers, { triviaAPIDetails } from '@/helpers'
 
 describe('helpers', () => {
   test('buildAPI_URL function', () => {
     const BASE_URL = triviaAPIDetails.API_URL
     // no params passed - all default values applied in url
-    expect(helpers.buildAPI_URL(undefined, undefined, undefined)).toBe(`${BASE_URL}?limit=50&difficulty=easy,medium,hard&categories=science,film_and_tv,music,history,geography,art_and_literature,sport_and_leisure,general_knowledge,science,food_and_drink`)
+    expect(helpers.buildAPI_URL(undefined, undefined, undefined)).toBe(
+      `${BASE_URL}?limit=50&difficulty=easy,medium,hard&categories=science,film_and_tv,music,history,geography,art_and_literature,sport_and_leisure,general_knowledge,science,food_and_drink`
+    )
     // pass in some params - these are set into url
-    expect(helpers.buildAPI_URL(30, ['easy', 'medium'], ['science', 'sports'])).toBe(`${BASE_URL}?limit=30&difficulty=easy,medium&categories=science,sports`)
+    expect(
+      helpers.buildAPI_URL(30, ['easy', 'medium'], ['science', 'sports'])
+    ).toBe(
+      `${BASE_URL}?limit=30&difficulty=easy,medium&categories=science,sports`
+    )
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,14 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": "src/",
+    "paths": {
+      "@/assets/*": ["assets/*"],
+      "@/components/*": ["components/*"],
+      "@/styles/*": ["styles/*"],
+      "@/utils/*": ["utils/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
- set base url and some aliases for simplified imports:
- - instead of:
`import styles from '../styles/Home.module.css'`
can use:
`import styles from '@/styles/Home.module.css'` etc
- - regex to replace - 1..n occurances of `"../"` with `@/` (as above) -> `''.replace(/(\.\.\/)+([^/]+)/g, '@/$2')` ( or if want to name a capture group - amend inserting `?<capture_group_name>` inside as: `''.replace(/(\.\.\/)+(?<folder_name>[^/]+)/g, '@/$<folder_name>')` )
- (prettier has adjusted some code here also)
